### PR TITLE
KHBBS: Add character name to the mod.yml for the patch

### DIFF
--- a/worlds/khbbs/OpenKH.py
+++ b/worlds/khbbs/OpenKH.py
@@ -29,9 +29,20 @@ class KHBBSContainer(APContainer):
 def patch_khbbs(self, output_directory, character):
     mod_name = f"AP-{self.multiworld.seed_name}-P{self.player}-{self.multiworld.get_file_safe_player_name(self.player)}"
     mod_dir = os.path.join(output_directory, mod_name + "_" + Utils.__version__)
+    character_name = ""
     
     seed_lua = build_seed_lua(self, character)
-    
+
+    match character:
+        case 0:
+            character_name = "Ventus"
+        case 1:
+            character_name = "Aqua"
+        case 2:
+            character_name = "Terra"
+        case _:  # Used if somehow the character is not in range 0-2
+            character_name = "Invalid character"
+
     self.mod_yml = {
         "assets": [
             {
@@ -44,7 +55,7 @@ def patch_khbbs(self, output_directory, character):
                 ]
             }
         ],
-        'title':  'BBSFMAP Randomizer Seed'
+        'title':  f'BBSFMAP Randomizer Seed for {character_name}'
     }
     
     openkhmod = {


### PR DESCRIPTION
## What is this fixing or adding?
Adds the name of the character that will get randomized. This helps to know who to play as when character selection in the settings is random. Also helps when attempting to use multiple characters in 1 multiworld as you can easily load them into the mod manager and selected the wanted character based on the mod name.

## How was this tested?
Ran multiple generations with different settings and checked the mod.yml title. Also imported some into OpenKH.

## If this makes graphical changes, please attach screenshots.
![OpenKh Tools ModsManager_20102024191525](https://github.com/user-attachments/assets/dc2f05d7-174e-4f2c-a582-9314eb4af5b8)
