### PR TITLE
Eraqus and Monstro Logic fix

### DIFF
--- a/worlds/khbbs/Regions.py
+++ b/worlds/khbbs/Regions.py
@@ -269,8 +269,9 @@ def create_regions(multiworld: MultiWorld, player: int, options):
                 regions["Mirage Arena"].locations.append("(T) Mirage Arena Disney Drive: Finish 5 laps in 5 minutes")
                 regions["Mirage Arena"].locations.append("(T) Mirage Arena Grand Spree: Finish 5 laps in 5 minutes")
                 regions["Mirage Arena"].locations.append("(T) Mirage Arena Castle Circuit: Finish 5 laps in 5:30")
-            regions["Mirage Arena"].locations.append("(T) Mirage Arena Monster of the Sea Mini")
-            regions["Mirage Arena"].locations.append("(T) Mirage Arena Complete Monster of the Sea")
+            if options.arena_global_locations or options.minigames:
+                regions["Mirage Arena"].locations.append("(T) Mirage Arena Monster of the Sea Mini")
+                regions["Mirage Arena"].locations.append("(T) Mirage Arena Complete Monster of the Sea")
         if options.super_bosses:
             regions["The Land of Departure"].locations.append("(T) The Land of Departure Defeat Unknown No Name")
             regions["The Keyblade Graveyard"].locations.append("(T) The Keyblade Graveyard Defeat Vanitas Remnant Void Gear")
@@ -528,8 +529,9 @@ def create_regions(multiworld: MultiWorld, player: int, options):
                 regions["Mirage Arena"].locations.append("(A) Mirage Arena Disney Drive: Finish 5 laps in 5 minutes")
                 regions["Mirage Arena"].locations.append("(A) Mirage Arena Grand Spree: Finish 5 laps in 5 minutes")
                 regions["Mirage Arena"].locations.append("(A) Mirage Arena Castle Circuit: Finish 5 laps in 5:30")
-            regions["Mirage Arena"].locations.append("(A) Mirage Arena Monster of the Sea Mini")
-            regions["Mirage Arena"].locations.append("(A) Mirage Arena Complete Monster of the Sea")
+            if options.arena_global_locations or options.minigames:
+                regions["Mirage Arena"].locations.append("(A) Mirage Arena Monster of the Sea Mini")
+                regions["Mirage Arena"].locations.append("(A) Mirage Arena Complete Monster of the Sea")
         if options.super_bosses:
             regions["The Keyblade Graveyard"].locations.append("(A) The Keyblade Graveyard Defeat Vanitas Remnant Void Gear")
             regions["The Land of Departure"].locations.append("(A) The Land of Departure Defeat Unknown No Name")
@@ -781,8 +783,9 @@ def create_regions(multiworld: MultiWorld, player: int, options):
                 regions["Mirage Arena"].locations.append("(V) Mirage Arena Disney Drive: Finish 5 laps in 5 minutes")
                 regions["Mirage Arena"].locations.append("(V) Mirage Arena Grand Spree: Finish 5 laps in 5 minutes")
                 regions["Mirage Arena"].locations.append("(V) Mirage Arena Castle Circuit: Finish 5 laps in 5:30")
-            regions["Mirage Arena"].locations.append("(V) Mirage Arena Monster of the Sea Mini")
-            regions["Mirage Arena"].locations.append("(V) Mirage Arena Complete Monster of the Sea")
+            if options.arena_global_locations or options.minigames:
+                regions["Mirage Arena"].locations.append("(V) Mirage Arena Monster of the Sea Mini")
+                regions["Mirage Arena"].locations.append("(V) Mirage Arena Complete Monster of the Sea")
         if options.super_bosses:
             regions["The Keyblade Graveyard"].locations.append("(V) The Keyblade Graveyard Defeat Vanitas Remnant Void Gear")
             regions["The Land of Departure"].locations.append("(V) The Land of Departure Defeat Unknown No Name")

--- a/worlds/khbbs/Rules.py
+++ b/worlds/khbbs/Rules.py
@@ -295,18 +295,19 @@ def set_rules(khbbsworld):
                         has_x_worlds(state, player, 6)
                         and state.has("Radiant Garden", player)
                     ))
-                add_rule(khbbsworld.get_location("(T) Mirage Arena Monster of the Sea Mini"),
-                    lambda state: (
-                        has_x_worlds(state, player, 8)
-                        and state.has("Disney Town", player)
-                        and has_defensive_tools(state, player)
-                    ))
-                add_rule(khbbsworld.get_location("(T) Mirage Arena Complete Monster of the Sea"),
-                    lambda state: (
-                        has_x_worlds(state, player, 8)
-                        and state.has("Disney Town", player)
-                        and has_defensive_tools(state, player)
-                    ))
+                if options.minigames:
+                    add_rule(khbbsworld.get_location("(T) Mirage Arena Monster of the Sea Mini"),
+                        lambda state: (
+                            has_x_worlds(state, player, 8)
+                            and state.has("Disney Town", player)
+                            and has_defensive_tools(state, player)
+                        ))
+                    add_rule(khbbsworld.get_location("(T) Mirage Arena Complete Monster of the Sea"),
+                        lambda state: (
+                            has_x_worlds(state, player, 8)
+                            and state.has("Disney Town", player)
+                            and has_defensive_tools(state, player)
+                        ))
             add_rule(khbbsworld.get_location("(T) Mirage Arena Complete Day of Reckoning"),
                 lambda state: has_x_worlds(state, player, 2))
             add_rule(khbbsworld.get_location("(T) Mirage Arena Complete Risky Riches"),
@@ -639,18 +640,19 @@ def set_rules(khbbsworld):
                         has_x_worlds(state, player, 6)
                         and state.has("Radiant Garden", player)
                     ))
-                add_rule(khbbsworld.get_location("(A) Mirage Arena Monster of the Sea Mini"),
-                    lambda state: (
-                        has_x_worlds(state, player, 8)
-                        and state.has("Disney Town", player)
-                        and has_defensive_tools(state, player)
-                    ))
-                add_rule(khbbsworld.get_location("(A) Mirage Arena Complete Monster of the Sea"),
-                    lambda state: (
-                        has_x_worlds(state, player, 8)
-                        and state.has("Disney Town", player)
-                        and has_defensive_tools(state, player)
-                    ))
+                if options.minigames:
+                    add_rule(khbbsworld.get_location("(A) Mirage Arena Monster of the Sea Mini"),
+                        lambda state: (
+                            has_x_worlds(state, player, 8)
+                            and state.has("Disney Town", player)
+                            and has_defensive_tools(state, player)
+                        ))
+                    add_rule(khbbsworld.get_location("(A) Mirage Arena Complete Monster of the Sea"),
+                        lambda state: (
+                            has_x_worlds(state, player, 8)
+                            and state.has("Disney Town", player)
+                            and has_defensive_tools(state, player)
+                        ))
             add_rule(khbbsworld.get_location("(A) Mirage Arena Complete Day of Reckoning"),
                 lambda state: has_x_worlds(state, player, 2))
             add_rule(khbbsworld.get_location("(A) Mirage Arena Wheels of Misfortune Max HP Increase"),
@@ -972,18 +974,19 @@ def set_rules(khbbsworld):
                         has_x_worlds(state, player, 6)
                         and state.has("Radiant Garden", player)
                     ))
-                add_rule(khbbsworld.get_location("(V) Mirage Arena Monster of the Sea Mini"),
-                    lambda state: (
-                        has_x_worlds(state, player, 8)
-                        and state.has("Disney Town", player)
-                        and has_defensive_tools(state, player)
-                    ))
-                add_rule(khbbsworld.get_location("(V) Mirage Arena Complete Monster of the Sea"),
-                    lambda state: (
-                        has_x_worlds(state, player, 8)
-                        and state.has("Disney Town", player)
-                        and has_defensive_tools(state, player)
-                    ))
+                if options.minigames:
+                    add_rule(khbbsworld.get_location("(V) Mirage Arena Monster of the Sea Mini"),
+                        lambda state: (
+                            has_x_worlds(state, player, 8)
+                            and state.has("Disney Town", player)
+                            and has_defensive_tools(state, player)
+                        ))
+                    add_rule(khbbsworld.get_location("(V) Mirage Arena Complete Monster of the Sea"),
+                        lambda state: (
+                            has_x_worlds(state, player, 8)
+                            and state.has("Disney Town", player)
+                            and has_defensive_tools(state, player)
+                        ))
             add_rule(khbbsworld.get_location("(V) Mirage Arena Complete Day of Reckoning"),
                 lambda state: has_x_worlds(state, player, 2))            
             add_rule(khbbsworld.get_location("(V) Mirage Arena Complete Risky Riches"),

--- a/worlds/khbbs/Rules.py
+++ b/worlds/khbbs/Rules.py
@@ -75,26 +75,11 @@ def set_rules(khbbsworld):
     # Location Rules
     if options.character == 2:
         add_rule(khbbsworld.get_location("(T) The Land of Departure Defeat Eraqus Max HP Increase"),
-            lambda state: (
-                state.has_all({
-                "Wayfinder Ventus",
-                "Wayfinder Aqua",
-                "Wayfinder Terra"}, player)
-            ))
+            lambda state: has_x_worlds(state, player, 6))
         add_rule(khbbsworld.get_location("(T) The Land of Departure Defeat Eraqus Chaos Ripper"),
-            lambda state: (
-                state.has_all({
-                "Wayfinder Ventus",
-                "Wayfinder Aqua",
-                "Wayfinder Terra"}, player)
-            ))
+            lambda state: has_x_worlds(state, player, 6))
         add_rule(khbbsworld.get_location("(T) The Land of Departure Defeat Eraqus Xehanort's Report 8"),
-            lambda state: (
-                state.has_all({
-                "Wayfinder Ventus",
-                "Wayfinder Aqua",
-                "Wayfinder Terra"}, player)
-            ))
+            lambda state: has_x_worlds(state, player, 6))
         add_rule(khbbsworld.get_location("(T) Dwarf Woodlands Vault Flame Salvo Chest"),
             lambda state: (
                 has_fire(state, player, minigames)


### PR DESCRIPTION
Changed Terra's Eraqus fight logic to ensure Unknown is always accessible logically
Monstro Arena fight is only added with Global Locations off if Disney Town is completable